### PR TITLE
Callout info improvements

### DIFF
--- a/Callouts/ActiveShooter.cs
+++ b/Callouts/ActiveShooter.cs
@@ -8,7 +8,7 @@ using Rage.Native;
 namespace YobbinCallouts.Callouts
 {
     // [CalloutInterface("Active Shooter", CalloutProbability.Medium, "Active Shooter", "Code 99")] //test to see if this works without calloutinterface installed!!
-    [CalloutInfo("Active Shooter", CalloutProbability.High)]
+    [CalloutInfo("[YC] Active Shooter", CalloutProbability.High)]
     public class ActiveShooter : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/Arson.cs
+++ b/Callouts/Arson.cs
@@ -10,7 +10,7 @@ using YobbinCallouts.Utilities;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Arson", CalloutProbability.High)]
+    [CalloutInfo("[YC] Arson", CalloutProbability.High)]
 
     public class Arson : Callout
     {

--- a/Callouts/AssaultOnBus.cs
+++ b/Callouts/AssaultOnBus.cs
@@ -19,7 +19,7 @@ using System.Collections;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Assault On Bus", CalloutProbability.Medium)]
+    [CalloutInfo("[YC] Assault On Bus", CalloutProbability.Medium)]
     public class AssaultOnBus : Callout
     {
         //SPAWN POINTS

--- a/Callouts/BaitCar.cs
+++ b/Callouts/BaitCar.cs
@@ -12,7 +12,7 @@ using CalloutInterfaceAPI;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInterface("Bait Car", CalloutProbability.Medium, "")]
+    [CalloutInterface("[YC] Bait Car", CalloutProbability.Medium, "")]
 
     public class BaitCar : Callout
     {

--- a/Callouts/BarFight.cs
+++ b/Callouts/BarFight.cs
@@ -8,7 +8,7 @@ using System.Collections;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Bar Fight", CalloutProbability.High)]
+    [CalloutInfo("[YC] Bar Fight", CalloutProbability.High)]
     public class BarFight : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/BrokenDownVehicle.cs
+++ b/Callouts/BrokenDownVehicle.cs
@@ -23,7 +23,7 @@ using YobbinCallouts.Utilities;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Broken Down Vehicle", CalloutProbability.High)]
+    [CalloutInfo("[YC] Broken Down Vehicle", CalloutProbability.High)]
 
     public class BrokenDownVehicle : Callout
     {

--- a/Callouts/CitizenArrest.cs
+++ b/Callouts/CitizenArrest.cs
@@ -11,7 +11,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Citizen's Arrest", CalloutProbability.High)]
+    [CalloutInfo("[YC] Citizen Arrest", CalloutProbability.High)]
     public class CitizenArrest : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/DUIReported.cs
+++ b/Callouts/DUIReported.cs
@@ -11,7 +11,7 @@ using System.Drawing;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("DUI Reported", CalloutProbability.High)]
+    [CalloutInfo("[YC] DUI Reported", CalloutProbability.High)]
     class DUIReported : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/HospitalEmergency.cs
+++ b/Callouts/HospitalEmergency.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Hospital Emergency", CalloutProbability.High)]
+    [CalloutInfo("[YC] Hospital Emergency", CalloutProbability.High)]
     class HospitalEmergency : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/HumanTrafficking.cs
+++ b/Callouts/HumanTrafficking.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Human Trafficking", CalloutProbability.Medium)]
+    [CalloutInfo("[YC] Human Trafficking", CalloutProbability.Medium)]
     public class HumanTrafficking : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/LandlordTenantDispute.cs
+++ b/Callouts/LandlordTenantDispute.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Landlord-Tenant Dispute", CalloutProbability.High)]
+    [CalloutInfo("[YC] Landlord-Tenant Dispute", CalloutProbability.High)]
     class LandlordTenantDispute : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/PedestrianHitByVehicle.cs
+++ b/Callouts/PedestrianHitByVehicle.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Pedestrian Hit By Vehicle", CalloutProbability.High)]
+    [CalloutInfo("[YC] Pedestrian Hit By Vehicle", CalloutProbability.High)]
 
     class PedestrianHitByVehicle : Callout
     {

--- a/Callouts/PersonWithWeapon.cs
+++ b/Callouts/PersonWithWeapon.cs
@@ -8,7 +8,7 @@
 
 //namespace YobbinCallouts.Callouts
 //{
-//    [CalloutInfo("Person With a Weapon", CalloutProbability.High)]
+//    [CalloutInfo("[YC] Person With a Weapon", CalloutProbability.High)]
 
 //    class PersonWithWeapon : Callout
 //    {

--- a/Callouts/PhotographyOfPrivateProperty.cs
+++ b/Callouts/PhotographyOfPrivateProperty.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Photography of Private Property", CalloutProbability.High)]
+    [CalloutInfo("[YC] Photography of Private Property", CalloutProbability.High)]
 
     public class PhotographyOfPrivateProperty : Callout
     {

--- a/Callouts/PropertyCheck.cs
+++ b/Callouts/PropertyCheck.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Property Checkup", CalloutProbability.High)]
+    [CalloutInfo("[YC] Property Checkup", CalloutProbability.High)]
 
     public class PropertyCheck : Callout
     {

--- a/Callouts/RoadRage.cs
+++ b/Callouts/RoadRage.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Road Rage", CalloutProbability.High)] //Change later
+    [CalloutInfo("[YC] Road Rage", CalloutProbability.High)] //Change later
     public class RoadRage : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/Sovereign Citizen.cs
+++ b/Callouts/Sovereign Citizen.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Sovereign Citizen", CalloutProbability.High)] //Change later
+    [CalloutInfo("[YC] Sovereign Citizen", CalloutProbability.High)] //Change later
     public class SovereignCitizen : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/StolenCellPhone.cs
+++ b/Callouts/StolenCellPhone.cs
@@ -10,7 +10,7 @@ using System;
 //This Callout was inspired by a LivePD Call.
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Stolen Cellphone", CalloutProbability.Medium)]
+    [CalloutInfo("[YC] Stolen Cellphone", CalloutProbability.Medium)]
 
     public class StolenCellPhone : Callout
     {

--- a/Callouts/StolenMail.cs
+++ b/Callouts/StolenMail.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Stolen Mail", CalloutProbability.Medium)]
+    [CalloutInfo("[YC] Stolen Mail", CalloutProbability.Medium)]
     public class StolenMail : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/StolenPoliceHardware.cs
+++ b/Callouts/StolenPoliceHardware.cs
@@ -9,7 +9,7 @@ using YobbinCallouts.Utilities;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Stolen Police Hardware", CalloutProbability.High)]
+    [CalloutInfo("[YC] Stolen Police Hardware", CalloutProbability.High)]
     class StolenPoliceHardware : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/TrafficBreak.cs
+++ b/Callouts/TrafficBreak.cs
@@ -8,7 +8,7 @@ using System;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Traffic Break", CalloutProbability.Medium)] //Change later
+    [CalloutInfo("[YC] Traffic Break", CalloutProbability.Medium)] //Change later
     public class TrafficBreak : Callout
     {
         private Vector3 MainSpawnPoint;

--- a/Callouts/WeaponFound.cs
+++ b/Callouts/WeaponFound.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 
 namespace YobbinCallouts.Callouts
 {
-    [CalloutInfo("Weapon Found", CalloutProbability.High)]
+    [CalloutInfo("[YC] Weapon Found", CalloutProbability.High)]
     class WeaponFound : Callout
     {
         public Vector3 MainSpawnPoint;


### PR DESCRIPTION
- added a `[YC]` tag before the callout names in the callout info code to help differentiate them from other callouts in logs
- fixed incorrectly spelled `Citizen's` [Arrest]

fixes #12 